### PR TITLE
Add Version to ARP

### DIFF
--- a/scilab/tools/innosetup/setup.iss
+++ b/scilab/tools/innosetup/setup.iss
@@ -32,6 +32,7 @@ OutputBaseFilename={#ScilabBaseFilename}-nojre
 #endif
 AppName={#ScilabName}
 AppVerName={#ScilabName}
+AppVersion={#ScilabVersion}
 ;always shown welcome page
 DisableWelcomePage=no
 ;always shown destination path page


### PR DESCRIPTION
Programs like the [Windows Package Manager](https://github.com/microsoft/winget-cli) rely on the values in Add / Remove Programs to verify the package version. This change populates the version into the ARP entry